### PR TITLE
Return empty array instead of nil when there are no filter results

### DIFF
--- a/lib/tukey/data_set.rb
+++ b/lib/tukey/data_set.rb
@@ -158,8 +158,6 @@ class DataSet
       elsif condition_met.nil? && set.leaf?
         parent_set.add_item(set_dup) if keep_leafs
       end
-
-      parent_set
     end
   end
 

--- a/lib/tukey/data_set.rb
+++ b/lib/tukey/data_set.rb
@@ -130,7 +130,7 @@ class DataSet
     fail 'Cannot filter value DataSets' unless data_array?
     return self.dup if self.data.empty?
 
-    self.data.each_with_object(DataSet.new(id: id, label: label.deep_dup)) do |set, parent_set|
+    self.data.each_with_object(DataSet.new(id: id, label: label.deep_dup, data: [])) do |set, parent_set|
       if block_given?
         condition_met = yield(parent_set, set)
       else
@@ -147,7 +147,7 @@ class DataSet
         deep_filter_result = set_dup.filter(leaf_label_id, keep_leafs: keep_leafs, orphan_strategy: orphan_strategy, &block)
 
         # Here is where either the taking along or adopting of nodes happens
-        if deep_filter_result.data
+        if deep_filter_result.data && !deep_filter_result.data.empty?
           # Filtering underlying children and adding the potential filter result to parent.
           parent_set.add_item(deep_filter_result) if condition_met.nil?
 

--- a/spec/data_set_spec.rb
+++ b/spec/data_set_spec.rb
@@ -612,7 +612,7 @@ describe DataSet do
 
           it 'returns the correct subset as a new dataset' do
             filter_result = subject.filter(label_2013.id)
-            expect(filter_result == expected_ds).to eq true
+            expect(filter_result).to eq expected_ds
           end
         end
 

--- a/spec/data_set_spec.rb
+++ b/spec/data_set_spec.rb
@@ -620,7 +620,7 @@ describe DataSet do
           it 'returns an empty dataset with the same label as the set .filter was called on' do
             filter_result = subject.filter('You shall not find... me')
             expect(filter_result.label).to eq subject.label
-            expect(filter_result.data).to be_nil
+            expect(filter_result.data).to eq []
           end
         end
       end
@@ -661,7 +661,7 @@ describe DataSet do
           it 'returns an empty set with the same label as filter was called on' do
             filter_result = subject.filter { false }
             expect(filter_result.label).to eq subject.label
-            expect(filter_result.data).to be_nil
+            expect(filter_result.data).to eq []
           end
         end
 
@@ -669,7 +669,7 @@ describe DataSet do
           it 'returns an empty set with the same label as filter was called on' do
             filter_result = subject.filter { nil }
             expect(filter_result.label).to eq subject.label
-            expect(filter_result.data).to be_nil
+            expect(filter_result.data).to eq []
           end
         end
 


### PR DESCRIPTION
Dit fixt dit issue: https://github.com/CO2Management/co2m/issues/2486